### PR TITLE
Fixed build on 64-bits hosts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,12 +12,12 @@ BIN_DIRS  = kernel fish
 BIN_DIRS += $(DRIVERS) $(DAEMONS) $(UTILS) $(PORTS) $(APPS)
 
 CC := clang -m32
-LD := ld
+LD := ld -melf_i386
 AR := ar
 AS := nasm
 PP := cpp
 
-CFLAGS	:= -pipe -Wall -Werror -Wextra -pedantic -std=c99
+CFLAGS	:= -pipe -Wall -Werror -Wextra -pedantic -std=c99 
 CFLAGS	+= -Wpointer-arith -Wwrite-strings
 CFLAGS	+= -Wno-unused-parameter -Wno-unused-function
 CFLAGS	+= -O3 -fomit-frame-pointer


### PR DESCRIPTION
I've just discovered your project and when I tried to build it, I got this error :
    ld: i386 architecture of input file `./irq/irq.o' is incompatible with i386:x86-64 output

This change fixed this issue and I'm now able to test your OS in qemu :)
