### PR TITLE
optimized __widget_event and added option to use IRQs in mouse driver

### DIFF
--- a/driver/mouse/main.c
+++ b/driver/mouse/main.c
@@ -24,7 +24,16 @@
 #include <rdi/vfs.h>
 #include <rdi/arch.h>
 
+#define USE_IRQ 0
+
 struct event_list *event_list;
+uint8_t bytes[3];
+size_t curbyte;
+int16_t dx, dy;
+int buttons, prevbuttons;
+#if USE_IRQ
+bool mutex;
+#endif
 
 void wait_signal() {
 	while (inb(0x64) & 0x2);
@@ -62,13 +71,56 @@ char *mouse_deregister(uint64_t source, uint32_t index, int argc, char **argv) {
 	return strdup("T");
 }
 
-int main(int argc, char **argv) {
-	uint8_t bytes[3];
-	size_t curbyte = 0;
-	bool first;
-	int buttons = 0, prevbuttons = 0;
-	int16_t dx = 0, dy = 0;
+void read_byte() {
+	bytes[curbyte++] = inb(0x60);
+
+	if (curbyte == 1) {
+		buttons = bytes[0] & 0x7;
+		if (!(bytes[0] & 0x08)) {
+			// Out of sync
+			curbyte = 0;
+		}
+	}
+	if (curbyte == 3) {
+		curbyte = 0;
+		dx += bytes[1] - ((bytes[0] & 0x10) ? 256 : 0);
+		dy -= bytes[2] - ((bytes[0] & 0x20) ? 256 : 0);
+	}
+}
+
+void send_events() {
 	char *event;
+
+	if (dx || dy) {
+		event = saprintf("mouse delta %d %d", dx, dy);
+		eventl(event_list, event);
+		free(event);
+		dx = dy = 0;
+	}
+
+	if (buttons != prevbuttons) {
+		event = saprintf("mouse button %d", buttons);
+		eventl(event_list, event);
+		free(event);
+		prevbuttons = buttons;
+	}
+}
+
+#if USE_IRQ
+void mouse_irq(struct msg *msg) {
+	mutex_spin(&mutex);
+	read_byte();
+	send_events();
+	mutex_free(&mutex);
+}
+#endif
+
+int main(int argc, char **argv) {
+#if USE_IRQ
+	uint8_t status;
+#else
+	bool first;
+#endif
 
 	command(0xa8);  // enable aux. PS2
 	command(0xf6);  // load default config
@@ -76,51 +128,47 @@ int main(int argc, char **argv) {
 	command(0xf3);  // set sample rate:
 	outb(0x60, 10); // 10 samples per second
 
+#if USE_IRQ
+	wait_signal();
+	outb(0x64, 0x20);
+	status = inb(0x60);
+	status &= ~0x20; // enable mouse clock
+	status |= 0x02;  // enable IRQ12
+	wait_signal();
+	outb(0x64, 0x60);
+	wait_signal();
+	outb(0x60, status);
+	wait_signal();
+#endif
+
 	index_set(0, resource_cons(FS_TYPE_FILE | FS_TYPE_EVENT, PERM_READ | PERM_WRITE));
 
 	rcall_set("register",   mouse_register);
 	rcall_set("deregister", mouse_deregister);
+#if USE_IRQ
+	rdi_set_irq(12, mouse_irq);
+#endif
 	rdi_init_all();
 
 	fs_plink("/dev/mouse", RP_CONS(getpid(), 0), NULL);
 	msendb(RP_CONS(getppid(), 0), PORT_CHILD);
 
+#if USE_IRQ
+	_done();
+#else
 	while (1) {
 		first = true;
 		while ((inb(0x64) & 0x21) != 0x21) {
 			if (first) {
-				if (dx || dy) {
-					event = saprintf("mouse delta %d %d", dx, dy);
-					eventl(event_list, event);
-					free(event);
-					dx = dy = 0;
-				}
-				if (buttons != prevbuttons) {
-					event = saprintf("mouse button %d", buttons);
-					eventl(event_list, event);
-					free(event);
-					prevbuttons = buttons;
-				}
+				send_events();
 			}
 			first = false;
 			sleep();
 		}
 
-		bytes[curbyte++] = inb(0x60);
-
-		if (curbyte == 1) {
-			buttons = bytes[0] & 0x7;
-			if (!(bytes[0] & 0x08)) {
-				// Out of sync
-				curbyte = 0;
-			}
-		}
-		if (curbyte == 3) {
-			curbyte = 0;
-			dx += bytes[1] - ((bytes[0] & 0x10) ? 256 : 0);
-			dy -= bytes[2] - ((bytes[0] & 0x20) ? 256 : 0);
-		}
+		read_byte();
 	}
+#endif
 	
 	return 0;
 }

--- a/libtoolkit/widget.c
+++ b/libtoolkit/widget.c
@@ -170,7 +170,7 @@ static int __widget_event(struct widget *widget, const char *event, int argc, ch
 	for (ptr = widget->children; ptr; ptr = ptr->next) {
 		if ((ptr->realx <= mousex && mousex <= ptr->realx + ptr->realwidth) &&
 				(ptr->realy <= mousey && mousey <= ptr->realy + ptr->realheight)) {
-			if (!widget_event(ptr, event, argc, argv)) {
+			if (!__widget_event(ptr, event, argc, argv, mousex, mousey)) {
 				return 0;
 			}
 		}


### PR DESCRIPTION
Using IRQs in mouse driver is currently too slow, so it's disabled by default.
